### PR TITLE
docs: add Discord community links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
-  <h3>💬 Join our community on <a href="https://discord.gg/epxHVS5FWC">Discord</a>!</h3>
-  <p>A support community for this project — get help, share feedback, and connect with other users.</p>
+  <h3>💬 Join the <a href="https://discord.gg/epxHVS5FWC">Switch Support Discord</a>!</h3>
+  <p>Community support for running this project on Nintendo Switch — get help, share feedback, and connect with other users.</p>
 </div>
 
 <div align="center">
@@ -9,7 +9,7 @@
   <p align="center">
     <a href="https://twilitrealm.dev">Official Website</a>
     •
-    <a href="https://discord.gg/6NpMhefCK9">Discord</a>
+    <a href="https://discord.gg/6NpMhefCK9">Official Discord (PC)</a>
   </p>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 <div align="center">
+  <h3>💬 Join our community on <a href="https://discord.gg/epxHVS5FWC">Discord</a>!</h3>
+  <p>A support community for this project — get help, share feedback, and connect with other users.</p>
+</div>
+
+<div align="center">
   <img src="res/logo.png" alt="Logo" width="640">
 
   <p align="center">


### PR DESCRIPTION
## Summary

Adds Discord community links to the top of the README and clarifies the purpose of each server.

- **Top callout** → Switch Support Discord (`epxHVS5FWC`): community support for running the project on Nintendo Switch.
- **Header link** → relabeled to "Official Discord (PC)" (`6NpMhefCK9`): the official project creator's server for PC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEYgKR7VJDnQTLYfgPAs4m)_